### PR TITLE
Convert old docs files to new GitHub Copilot instructions files

### DIFF
--- a/documentation.txt
+++ b/documentation.txt
@@ -385,3 +385,10 @@ Section 04: Database interactions with GitHub Copilot chat
 -create variable const userLinks
 -in jsx add card components and elements with Tailwind CSS classes
 -open route: http://localhost:3000/dashboard
+
+
+27. Convert old docs files to new GitHub Copilot instructions files
+
+-open folder .github and create folder instructions
+-update instructions in .md files
+-delete folder docs

--- a/link-shortener/.github/agents/instructions-generator.agent.md
+++ b/link-shortener/.github/agents/instructions-generator.agent.md
@@ -1,7 +1,7 @@
 ---
 name: Instructions Generator
-description: "This agent generates highly specific agent instruction files for the /docs directory"
+description: "This agent generates highly specific agent instruction files."
 tools: ["read", "edit", "search", "web"]
 ---
 
-This agent takes the provided information about a layer of architecture or coding standards within this app and generates a concise and clear .md instructions file in markdown format for the /docs directory.
+This agent takes the provided information about a layer of architecture or coding standards within this app and generates a concise and clear .md instructions file in markdown format.

--- a/link-shortener/.github/instructions/authentication.instructions.md
+++ b/link-shortener/.github/instructions/authentication.instructions.md
@@ -1,3 +1,7 @@
+---
+description: Read this before implementing or modifying authentication in the project.
+---
+
 # Authentication Guidelines
 
 This document provides specific guidelines for implementing and working with authentication in this project.
@@ -81,7 +85,7 @@ import { SignInButton, SignUpButton } from "@clerk/nextjs";
 </SignUpButton>
 ```
 
-### DO NOT
+### DO NOT:
 
 - Create custom authentication forms
 - Implement password validation or storage
@@ -99,7 +103,7 @@ import { SignInButton, SignUpButton } from "@clerk/nextjs";
 
 Required in `.env.local`:
 
-```env
+```
 NEXT_PUBLIC_CLERK_PUBLISHABLE_KEY=pk_...
 CLERK_SECRET_KEY=sk_...
 ```

--- a/link-shortener/.github/instructions/data-fetching.instructions.md
+++ b/link-shortener/.github/instructions/data-fetching.instructions.md
@@ -1,0 +1,17 @@
+---
+description: Read this file to understand how to fetch data in the project.
+---
+
+# Data Fetching Guidelines
+
+This document outlines the best practices and guidelines for fetching data in our Next.js application. Adhering to these guidelines will ensure consistency, performance, and maintainability across the codebase.
+
+## 1. Use Server Components for Data Fetching
+
+In Next.js, ALWAYS using Server Components for data fetching. NEVER use Client Components to fetch data.
+
+## 2. Data Fetching Methods
+
+ALWAYS use the helper functions in the /data directory to fetch data. NEVER fetch data directly in the components.
+
+ALL helper functions in the /data directory should use Drizzle ORM for database interactions.

--- a/link-shortener/.github/instructions/server-actions.instructions.md
+++ b/link-shortener/.github/instructions/server-actions.instructions.md
@@ -1,0 +1,177 @@
+---
+description: Read this file before implementing or modifying server actions for data mutations in the project.
+---
+
+# Server Actions Instructions
+
+## Overview
+
+All data mutations in this application must be performed using Next.js Server Actions. This ensures proper security, type safety, and separation of concerns.
+
+## Core Requirements
+
+### 1. File Structure
+
+- Server action files **MUST** be named `actions.ts`
+- Server actions **MUST** be colocated in the same directory as the component that calls them
+- Example: `app/dashboard/actions.ts` for actions called from `app/dashboard/page.tsx`
+
+### 2. Client-Server Boundary
+
+- Server actions **MUST** be called from client components
+- Add `"use server"` directive at the top of action files
+- Add `"use client"` directive to components calling server actions
+
+### 3. Type Safety
+
+- All data passed to server actions **MUST** have appropriate TypeScript types
+- **DO NOT** use the `FormData` TypeScript type
+- Define explicit interfaces or types for action parameters
+
+Example:
+
+```typescript
+interface CreateLinkInput {
+  url: string;
+  customSlug?: string;
+}
+
+export async function createLink(input: CreateLinkInput) {
+  // ...
+}
+```
+
+### 4. Validation
+
+- All input data **MUST** be validated using Zod
+- Define Zod schemas for each action's input
+- Validate at the beginning of every server action
+
+Example:
+
+```typescript
+import { z } from "zod";
+
+const createLinkSchema = z.object({
+  url: z.string().url(),
+  customSlug: z.string().optional(),
+});
+
+export async function createLink(input: unknown) {
+  const validated = createLinkSchema.parse(input);
+  // ...
+}
+```
+
+### 5. Authentication
+
+- All server actions **MUST** check for a logged-in user before proceeding
+- Use Clerk's `auth()` function to get the current user
+- Return an error object if user is not authenticated
+
+Example:
+
+```typescript
+import { auth } from "@clerk/nextjs/server";
+
+export async function createLink(input: CreateLinkInput) {
+  const { userId } = await auth();
+  if (!userId) {
+    return { error: "Unauthorized" };
+  }
+  // ...
+}
+```
+
+### 6. Database Operations
+
+- Server actions **MUST NOT** directly use Drizzle queries
+- All database operations **MUST** be done via helper functions
+- Helper functions are located in the `/data` directory
+- Server actions should call these helper functions
+
+Example:
+
+```typescript
+// ❌ Wrong - Direct Drizzle query in action
+export async function createLink(input: CreateLinkInput) {
+  const { userId } = await auth();
+  await db.insert(links).values({ ...input, userId });
+}
+
+// ✅ Correct - Using helper function
+import { createLinkForUser } from "@/data/links";
+
+export async function createLink(input: CreateLinkInput) {
+  const { userId } = await auth();
+  const validated = createLinkSchema.parse(input);
+  return await createLinkForUser(userId, validated);
+}
+```
+
+### 7. Error Handling
+
+- Server actions **MUST NOT** throw errors
+- Always return an object with either an `error` or `success` property
+- Use try-catch blocks to handle validation and database errors
+- Provide meaningful error messages to the client
+
+Example:
+
+```typescript
+export async function createLink(input: unknown) {
+  try {
+    const validated = createLinkSchema.parse(input);
+    const link = await createLinkForUser(userId, validated);
+    return { success: true, data: link };
+  } catch (error) {
+    return { error: "Failed to create link" };
+  }
+}
+```
+
+## Complete Example
+
+```typescript
+"use server";
+
+import { auth } from "@clerk/nextjs/server";
+import { z } from "zod";
+import { createLinkForUser } from "@/data/links";
+
+const createLinkSchema = z.object({
+  url: z.string().url(),
+  customSlug: z.string().min(3).optional(),
+});
+
+export async function createLink(input: unknown) {
+  // 1. Check authentication
+  const { userId } = await auth();
+  if (!userId) {
+    return { error: "Unauthorized" };
+  }
+
+  // 2. Validate input and perform database operation
+  try {
+    const validated = createLinkSchema.parse(input);
+    const link = await createLinkForUser(userId, validated);
+    return { success: true, data: link };
+  } catch (error) {
+    if (error instanceof z.ZodError) {
+      return { error: "Invalid input data" };
+    }
+    return { error: "Failed to create link" };
+  }
+}
+```
+
+## Summary Checklist
+
+- [ ] File named `actions.ts` and colocated with component
+- [ ] Called from client component
+- [ ] Uses explicit TypeScript types (not FormData)
+- [ ] Validates input with Zod
+- [ ] Checks authentication with `auth()`
+- [ ] Uses helper functions from `/data` directory for database operations
+- [ ] Returns error/success objects instead of throwing errors
+- [ ] Wrapped in try-catch blocks for proper error handling

--- a/link-shortener/.github/instructions/ui-components.instructions.md
+++ b/link-shortener/.github/instructions/ui-components.instructions.md
@@ -1,3 +1,7 @@
+---
+description: Read this before creating or modifying UI components in the project.
+---
+
 # UI Components Guidelines
 
 ## Overview
@@ -93,7 +97,7 @@ export function MyFeature() {
 
 ## Quick Reference
 
-- **Documentation:** [https://ui.shadcn.com]
+- **Documentation:** https://ui.shadcn.com
 - **Component Location:** `components/ui/`
 - **Configuration:** `components.json`
 - **Installation Command:** `npx shadcn@latest add [component]`

--- a/link-shortener/.github/prompts/create-copilot-instructions.prompt.md
+++ b/link-shortener/.github/prompts/create-copilot-instructions.prompt.md
@@ -1,0 +1,6 @@
+---
+agent: Instructions Generator
+---
+
+Take the information below and generate a [NAME].instructions.md file for it in the /.github/instructions directory. Generate an appropriate name for the [NAME] placeholder based on the generated content. Make sure the instructions are concise and not too long. If no information is provided below, prompt the user to give the necessary details about the layer of architecture or coding standards to document.
+The .md file should have frontmatter with a description property that informs copilot of when to use this set of instructions.

--- a/link-shortener/AGENTS.md
+++ b/link-shortener/AGENTS.md
@@ -9,37 +9,6 @@ This document provides comprehensive guidelines for AI agents and LLMs working o
 3. [Coding Standards](#coding-standards)
 4. [Documentation](#documentation)
 
-## ⚠️ CRITICAL: Required Reading Before Code Generation
-
-### 🚨 MANDATORY REQUIREMENT 🚨
-
-Before generating ANY code, you MUST:
-
-1. **READ the relevant documentation files** in the `/docs` directory that apply to your task
-2. **FOLLOW the patterns and guidelines** specified in those files
-3. **DO NOT proceed** with code generation until you have reviewed the applicable documentation
-
-This is **NOT OPTIONAL**. Failure to read the relevant documentation before generating code will result in:
-
-- Incorrect implementations that don't follow project patterns
-- Security vulnerabilities from improper authentication/authorization
-- Inconsistent UI components that don't match the project's design system
-- Wasted time fixing preventable mistakes
-
-### Required Documentation by Topic
-
-Consult these files based on the task at hand:
-
-- **🔐 [Authentication Guidelines](docs/authentication.md)** - **MUST READ** before implementing any authentication, route protection, user data access, or auth-related features
-- **🎨 [UI Components Guidelines](docs/ui-components.md)** - **MUST READ** before creating or installing any UI components, forms, buttons, or styled elements
-
-**Workflow:**
-
-1. Identify what you need to implement
-2. Read the corresponding documentation file(s) completely
-3. Apply the patterns and guidelines from the documentation
-4. Only then generate code
-
 ## Project Overview
 
 This is a link shortener application built with modern web technologies. The application allows users to:

--- a/link-shortener/app/dashboard/page.tsx
+++ b/link-shortener/app/dashboard/page.tsx
@@ -19,7 +19,7 @@ const DashboardPage = async () => {
   const userLinks = await getUserLinks(userId);
 
   return (
-    <main className='container mx-auto py-8'>
+    <main className='container mx-auto p-8'>
       <div className='mb-8'>
         <h1 className='text-3xl font-bold mb-2'>Dashboard</h1>
         <p className='text-muted-foreground'>Manage your shortened links</p>


### PR DESCRIPTION
Moved documentation files from /docs to /.github/instructions with frontmatter descriptions. Added new instruction files for data fetching and server actions. Updated AGENTS.md to remove references to the old /docs directory. Adjusted dashboard page padding and made minor improvements to documentation and agent prompt files.