### PR TITLE
Extending the postToolUse hook logic with GitHub Copilot CLI

### DIFF
--- a/documentation.txt
+++ b/documentation.txt
@@ -475,13 +475,26 @@ Section 05: Extras
 -type command: /diff
 
 
-33. Detect insecure code with GitHub Copilot Chat
+33. Extending the postToolUse hook logic with GitHub Copilot CLI
+
+-update format.json file
+-create tool-output.json file
+-create format-on-edit.sh file
+-open terminal and type command: copilot
+-open GitHub Copilot CLI and type command for updating the bash property in tool-output.json file
+-allow code update
+-restart Github Copilot after adding a new one
+-add a prompt to create folder test with component page.tsx
+-open folder tmp to see generated .json files
+
+
+34. Detect insecure code with GitHub Copilot Chat
 
 -in folder prompts create security-audit.prompt.md file
 -open Copilot Chat and type command: /security-audit
 
 
-34. Sub agents with GitHub Copilot Chat
+35. Sub agents with GitHub Copilot Chat
 
 -add a prompt for fixing security issues in folder link-shortener
 -export GitHub Copilot Chat as .json file

--- a/link-shortener/.github/hooks/format-on-edit.sh
+++ b/link-shortener/.github/hooks/format-on-edit.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+# Read JSON from stdin
+json_input=$(cat)
+
+# Extract toolName from JSON
+tool_name=$(echo "$json_input" | jq -r '.toolName')
+
+# Only run prettier if toolName is "create" or "edit"
+if [ "$tool_name" = "create" ] || [ "$tool_name" = "edit" ]; then
+  npx prettier --write .
+fi

--- a/link-shortener/.github/hooks/format.json
+++ b/link-shortener/.github/hooks/format.json
@@ -1,11 +1,10 @@
 {
   "version": 1,
   "hooks": {
-    "preToolUse": [
+    "postToolUse": [
       {
         "type": "command",
-        "bash": "npx prettier --write .",
-        "description": "Running Prettier to format code"
+        "bash": ".github/hooks/format-on-edit.sh"
       }
     ]
   }

--- a/link-shortener/.github/hooks/tool-output.json
+++ b/link-shortener/.github/hooks/tool-output.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "hooks": {
+    "postToolUse": [
+      {
+        "type": "command",
+        "powershell": "$timestamp = [DateTimeOffset]::UtcNow.ToUnixTimeSeconds(); $input | Out-File -FilePath \"tmp/$timestamp.json\" -Encoding utf8"
+      }
+    ]
+  }
+}


### PR DESCRIPTION
Add a new bash hook script (link-shortener/.github/hooks/format-on-edit.sh) that runs Prettier when toolName is "create" or "edit". Update hooks config (link-shortener/.github/hooks/format.json) to use postToolUse and invoke the new script instead of running Prettier inline. Add link-shortener/.github/hooks/tool-output.json to persist tool output JSON files to tmp/ with a timestamped filename via PowerShell. Update documentation.txt to reflect the new hook flow and related steps.